### PR TITLE
.gradle is detected even if it is a directory, so fix directories so they are not detected

### DIFF
--- a/plugin/src/main/groovy/com/github/konifar/gradle/remover/remover/AbstractRemover.groovy
+++ b/plugin/src/main/groovy/com/github/konifar/gradle/remover/remover/AbstractRemover.groovy
@@ -77,10 +77,14 @@ abstract class AbstractRemover {
         moduleSrcDirs.collect { new File(it) }
                 .findAll { it.exists() }
                 .each { srcDirFile ->
-            srcDirFile.eachFileMatch(FILE_TYPE_FILTER) { f ->
-                stringBuilder.append(f.text.replaceAll('\n', '').replaceAll(' ', ''))
-            }
-        }
+                    srcDirFile.eachFileMatch(FILE_TYPE_FILTER) { f ->
+                        if (!f.isDirectory()) {
+                            stringBuilder.append(f.text.replaceAll('\n', '').replaceAll(' ', ''))
+                        } else {
+                            ColoredLogger.log "Skip '${f.path}' because it is a directory."
+                        }
+                    }
+                }
 
         moduleSrcDirs
                 .collect { new File("${it}/src") }


### PR DESCRIPTION
Fix the .gradle so that directories are not detected, since .gradle is detected even if it is a directory, and the presence of a .gradle directory will cause a force termination with an exception.