### PR TITLE
Support cashapp/paraphrase

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath 'app.cash.paraphrase:app.cash.paraphrase.gradle.plugin:0.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "gradle.plugin.com.github.konifar.gradle:plugin:0.3.3"
         // For mavenLocal

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.github.konifar.gradle.unused-resources-remover'
+apply plugin: 'app.cash.paraphrase'
 
 android {
     namespace = 'com.konifar.aurr'
@@ -10,7 +11,7 @@ android {
     compileSdk 33
 
     defaultConfig {
-        minSdk 19
+        minSdk 24
         targetSdk 33
         versionCode 1
         versionName "1.0.0"

--- a/example/src/main/java/com/konifar/aurr/MainFragment.kt
+++ b/example/src/main/java/com/konifar/aurr/MainFragment.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import app.cash.paraphrase.getString
 
 class MainFragment : Fragment() {
 
@@ -27,6 +28,8 @@ class MainFragment : Fragment() {
         textView.setPadding(padding, padding, padding, padding)
 
         AnimatorInflater.loadAnimator(context, R.animator.used_in_kotlin_animator)
+        view.findViewById<TextView>(R.id.used_parahrase).text =
+            resources.getString(FormattedResources.paraphrase(123))
 
         return view
     }

--- a/example/src/main/res/layout/used_in_fragment_layout.xml
+++ b/example/src/main/res/layout/used_in_fragment_layout.xml
@@ -48,4 +48,9 @@
         android:layout_height="wrap_content"
         android:src="@drawable/used_in_layout_as_nine_patch_drawable" />
 
+    <TextView
+        android:id="@+id/used_parahrase"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
 </android.support.constraint.ConstraintLayout>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -7,4 +7,6 @@
     <string name="used_font_awesome2">&#xf12a;</string>
     <string name="used_font_japanese">使っている文字</string>
     <string name="unused">Unused</string>
+    <string name="paraphrase">count: {count}</string>
+    <string name="unused_paraphrase">count: {count}</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/plugin/src/main/groovy/com/github/konifar/gradle/remover/remover/SearchPattern.groovy
+++ b/plugin/src/main/groovy/com/github/konifar/gradle/remover/remover/SearchPattern.groovy
@@ -24,7 +24,8 @@ class SearchPattern {
                 def pattern = /(@(${resourceName}|${resourceName}StateList)\/${target}[\s!"#\$%&'()\*\+\-\,\\\/:;<=>?@\[\\\]`{|}~])|(R\.${resourceName}\.${target})|(${toCamelCase(target)}Binding)/
                 return pattern
             default:
-                def pattern = /(@(${resourceName}|${resourceName}StateList)\/${target}[\s!"#\$%&'()\*\+\-\,\\\/:;<=>?@\[\\\]`{|}~])|(R\.${resourceName}\.${target})/
+                // Considered cashapp/paraphrase
+                def pattern = /(@(${resourceName}|${resourceName}StateList)\/${target}[\s!"#\$%&'()\*\+\-\,\\\/:;<=>?@\[\\\]`{|}~])|(R\.${resourceName}\.${target})|(FormattedResources\.${target}\(.+\))/
                 return pattern
         }
     }

--- a/plugin/src/test/groovy/com/github/konifar/gradle/remover/remover/valuetype/StringXmlValueRemoverTest.groovy
+++ b/plugin/src/test/groovy/com/github/konifar/gradle/remover/remover/valuetype/StringXmlValueRemoverTest.groovy
@@ -22,19 +22,25 @@ class StringXmlValueRemoverTest extends Specification {
         XmlValueRemover.isPatternMatched(fileText, pattern) == expected
 
         where:
-        fileText              | expected
-        "R.string.app_name"   | true
-        "@string/app_name\""  | true
-        "@string/app_name<"   | true
-        "@string/app_name("   | true
-        "@string/app_name)"   | true
-        "@string/app_name}"   | true
-        "@string/app_name:"   | true
-        "@string/app_name "   | true
-        "@string/app_name\n"  | true
-        "@string/app_name"    | false
-        "R.string.app"        | false
-        "@string/app_name2\"" | false
-        "@style/app_name"     | false
+        fileText                               | expected
+        "R.string.app_name"                    | true
+        "@string/app_name\""                   | true
+        "@string/app_name<"                    | true
+        "@string/app_name("                    | true
+        "@string/app_name)"                    | true
+        "@string/app_name}"                    | true
+        "@string/app_name:"                    | true
+        "@string/app_name "                    | true
+        "@string/app_name\n"                   | true
+        "FormattedResources.app_name(123)"     | true
+        "FormattedResources.app_name(\"123\")" | true
+        "@string/app_name"                     | false
+        "R.string.app"                         | false
+        "@string/app_name2\""                  | false
+        "@style/app_name"                      | false
+        "FormattedResources.app_name()"        | false
+        "FormattedResources.app_name("         | false
+        "FormattedResources.app_name)"         | false
+        "FormattedResources.app_name"          | false
     }
 }


### PR DESCRIPTION
- Files automatically generated by cashapp/paraphrase are also scanned for unused resource remover
    - Add test cases for FormattedResources
    - Add used and unused FormattedResources to example module
- Setup cashapp/paraphrase
    - Add android.useAndroidX=true
    - Update example module's minSdk to 24
